### PR TITLE
Correct properties structure when adding dbolo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,9 @@ need to add the release to the deployment manifest, add the
             name:    dbolo
 
     properties:
-      bolo:
-        dbolo:
-          submission:
-            address: 10.0.0.1   # <--- change this
+      dbolo:
+        submission:
+          address: 10.0.0.1   # <--- change this
 
 
 Parts of a Bolo Deployment


### PR DESCRIPTION
When adding as documented the following errors were observed:

```
Error 100: Unable to render instance groups for deployment. Errors are:
   - Unable to render jobs for instance group 'cell_z1'. Errors are:
     - Unable to render templates for job 'dbolo'. Errors are:
       - Error filling in template 'ctl' (line 29: Can't find property '["dbolo.submission.address"]')
   - Unable to render jobs for instance group 'cell_z2'. Errors are:
     - Unable to render templates for job 'dbolo'. Errors are:
       - Error filling in template 'ctl' (line 29: Can't find property '["dbolo.submission.address"]')
   - Unable to render jobs for instance group 'router'. Errors are:
     - Unable to render templates for job 'dbolo'. Errors are:
       - Error filling in template 'ctl' (line 29: Can't find property '["dbolo.submission.address"]')
   - Unable to render jobs for instance group 'etcd'. Errors are:
     - Unable to render templates for job 'dbolo'. Errors are:
       - Error filling in template 'ctl' (line 29: Can't find property '["dbolo.submission.address"]')
```
